### PR TITLE
fix: PATH環境変数を設定して実行パスを明示化

### DIFF
--- a/xkeysnail.service
+++ b/xkeysnail.service
@@ -7,6 +7,7 @@ ExecStartPre=sleep 1
 Restart=on-failure
 ExecStart=/usr/bin/xkeysnail --quiet %h/.xkeysnail/config.py
 Environment=DISPLAY=:0
+Environment=PATH=/usr/bin
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
おそらくsystemdの更新で明示的に環境変数を指定する必要が発生した。
そもそもportageが`/usr/bin/env python`のshebangを`python`に変換しなければ問題にはならないのだが、
それを修正する正しい方法は見つからなかった。
